### PR TITLE
Javadoc fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ idea {
         inheritOutputDirs = true
     }
 }
+build.finalizedBy(javadoc)
 
 dependencies {
     // Web framework stuff

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Nov 12 12:15:32 CET 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/telraam/api/BatonResource.java
+++ b/src/main/java/telraam/api/BatonResource.java
@@ -45,6 +45,7 @@ public class BatonResource {
     }
 
     /**
+     * @param id the id to search for
      * @return a specific baton on the id
      */
     @GET @Path(ENTITY_PATH)
@@ -63,6 +64,8 @@ public class BatonResource {
 
     /**
      * Update a specific baton with the specified information
+     * @param id the id of the baton to update
+     * @return the response
      */
     @PUT @Path(ENTITY_PATH)
     public Response updateBaton(@PathParam(ID_NAME) Optional<Integer> id) {

--- a/src/main/java/telraam/beacon/Callback.java
+++ b/src/main/java/telraam/beacon/Callback.java
@@ -1,9 +1,11 @@
 package telraam.beacon;
 
 /**
-* Stupid interface for callbacks. You mind if I request Callback<Void, Void>?
+* Interface for callbacks with one parameter.
 *
 * @author  Arthur Vercruysse
+* @param <Output> The return value type
+* @param <Input> The type of the parameter
 */
 public interface Callback<Output, Input> {
     public Output handle(Input value);

--- a/src/main/java/telraam/beacon/EventGenerator.java
+++ b/src/main/java/telraam/beacon/EventGenerator.java
@@ -1,8 +1,8 @@
 package telraam.beacon;
 
 /**
-* Callback<Void, Event<B>> wrapper in disguise.
-* Exposing simpler methods to wrap in the right Event<B>.
+* {@link Callback Callback&lt;Void, Event&lt;B&gt;&gt;} wrapper in disguise.
+* Exposing simpler methods to wrap in the right {@link Event Event&lt;B&gt;}
 *
 * @author  Arthur Vercruysse
 */


### PR DESCRIPTION
Closes #25 

This makes it so the build task runs the javadoc task after completion. We should look into hosting the generated docs somewhere