### PR TITLE
Enable cors

### DIFF
--- a/.idea/sonarlint.xml
+++ b/.idea/sonarlint.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SonarLintProjectSettings">
+    <option name="bindingEnabled" value="true" />
+    <option name="projectKey" value="12urenloop_Telraam" />
+    <option name="serverId" value="telraam-cloud" />
+  </component>
+</project>


### PR DESCRIPTION
To allow other services to read our data in a browser, we need to fix CORS headers.