### PR TITLE
Add swagger 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ dependencies {
             'io.dropwizard:dropwizard-hibernate:' + dropwizardVersion,
             'io.dropwizard:dropwizard-auth:' + dropwizardVersion,
             'io.dropwizard:dropwizard-jdbi3:' + dropwizardVersion,
-
     )
     // Database
     implementation('com.h2database:h2:1.4.200')
@@ -71,6 +70,9 @@ dependencies {
     // JAX-B dependencies for JDK 9+  -> https://stackoverflow.com/a/43574427
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
     implementation 'org.glassfish.jaxb:jaxb-runtime:3.0.1'
+
+    // Swagger-UI
+    implementation 'com.smoketurner:dropwizard-swagger:2.0.0-1'
 }
 
 test {

--- a/src/main/java/telraam/App.java
+++ b/src/main/java/telraam/App.java
@@ -6,6 +6,8 @@ import io.dropwizard.jdbi3.bundles.JdbiExceptionsBundle;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import io.federecio.dropwizard.swagger.SwaggerBundle;
+import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.jdbi.v3.core.Jdbi;
 import telraam.api.*;
@@ -39,6 +41,13 @@ public class App extends Application<AppConfiguration> {
     public void initialize(Bootstrap<AppConfiguration> bootstrap) {
         // nothing to do yet
         bootstrap.addBundle(new JdbiExceptionsBundle());
+
+        bootstrap.addBundle(new SwaggerBundle<>() {
+            @Override
+            protected SwaggerBundleConfiguration getSwaggerBundleConfiguration(AppConfiguration configuration) {
+                return configuration.swaggerBundleConfiguration;
+            }
+        });
     }
 
 

--- a/src/main/java/telraam/AppConfiguration.java
+++ b/src/main/java/telraam/AppConfiguration.java
@@ -3,6 +3,7 @@ package telraam;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
+import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 import telraam.api.responses.Template;
 
 import javax.validation.Valid;
@@ -63,6 +64,8 @@ public class AppConfiguration extends Configuration {
     @JsonProperty("beaconPort")
     public void setBeaconPort(int port) {
         beaconPort = port;
-
     }
+
+    @JsonProperty("swagger")
+    public SwaggerBundleConfiguration swaggerBundleConfiguration;
 }

--- a/src/main/java/telraam/api/AbstractResource.java
+++ b/src/main/java/telraam/api/AbstractResource.java
@@ -1,6 +1,8 @@
 package telraam.api;
 
-import org.aopalliance.reflect.Class;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import telraam.database.daos.DAO;
 
 import javax.ws.rs.WebApplicationException;
@@ -16,12 +18,17 @@ public abstract class AbstractResource<T> implements Resource<T> {
     }
 
     @Override
-    public int create(T t) {
+    // TODO Validate model and return 405 for wrong input
+    public int create(@ApiParam(required = true) T t) {
         return dao.insert(t);
     }
 
     @Override
-    public T get(Optional<Integer> id) {
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Invalid or no ID supplied"), // TODO validate ID, return 400 on wrong ID format
+            @ApiResponse(code = 404, message = "Entity with specified ID not found")
+    })
+    public T get(@ApiParam(value = "ID of entity that needs to be fetched", required = true) Optional<Integer> id) {
         if (id.isPresent()) {
             Optional<T> optional = dao.getById(id.get());
             if (optional.isPresent()) {
@@ -35,7 +42,12 @@ public abstract class AbstractResource<T> implements Resource<T> {
     }
 
     @Override
-    public T update(T t, Optional<Integer> id) {
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Invalid or no ID supplied"), // TODO validate ID, return 400 on wrong ID format
+            @ApiResponse(code = 404, message = "Entity with specified ID not found"),
+            @ApiResponse(code = 405, message = "Validation exception")}) // TODO validate input, 405 on wrong input
+    public T update(@ApiParam(value = "Entity object that needs to be updated in the database", required = true) T t,
+                    @ApiParam(value = "ID of entity that needs to be fetched", required = true) Optional<Integer> id) {
         if (id.isPresent()) {
             Optional<T> optionalBaton = dao.getById(id.get());
             if (optionalBaton.isPresent()) {
@@ -50,7 +62,11 @@ public abstract class AbstractResource<T> implements Resource<T> {
     }
 
     @Override
-    public boolean delete(Optional<Integer> id) {
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Invalid or no ID supplied"), // TODO validate ID, return 400 on wrong ID format
+    })
+    public boolean delete(
+            @ApiParam(value = "ID of entity that needs to be fetched", required = true) Optional<Integer> id) {
         if (id.isPresent()) {
             return dao.deleteById(id.get()) == 1;
         } else {

--- a/src/main/java/telraam/api/BatonResource.java
+++ b/src/main/java/telraam/api/BatonResource.java
@@ -1,16 +1,50 @@
 package telraam.api;
 
+import io.swagger.annotations.*;
 import telraam.database.daos.BatonDAO;
 import telraam.database.models.Baton;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Optional;
 
-@Path("/baton")
+@Path("/baton") // dropwizard
+@Api(value = "/baton") // Swagger
 @Produces(MediaType.APPLICATION_JSON)
 public class BatonResource extends AbstractListableResource<Baton> {
     public BatonResource(BatonDAO dao) {
         super(dao);
+    }
+
+    @Override
+    @ApiOperation(value = "Find all batons")
+    public List<Baton> getListOf() {
+        return super.getListOf();
+    }
+
+    @Override
+    @ApiOperation(value = "Add a new baton to the database")
+    public int create(Baton baton) {
+        return super.create(baton);
+    }
+
+    @Override
+    @ApiOperation(value = "Find baton by ID")
+    public Baton get(Optional<Integer> id) {
+        return super.get(id);
+    }
+
+    @Override
+    @ApiOperation(value = "Update an existing baton")
+    public Baton update(Baton baton, Optional<Integer> id) {
+        return super.update(baton, id);
+    }
+
+    @Override
+    @ApiOperation(value = "Delete an existing baton")
+    public boolean delete(Optional<Integer> id) {
+        return super.delete(id);
     }
 }
 

--- a/src/main/java/telraam/api/BeaconResource.java
+++ b/src/main/java/telraam/api/BeaconResource.java
@@ -1,15 +1,51 @@
 package telraam.api;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import telraam.database.daos.DAO;
 import telraam.database.models.Beacon;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Optional;
 
 @Path("/beacon")
+@Api(value = "/beacon") // Swagger
 @Produces(MediaType.APPLICATION_JSON)
 public class BeaconResource extends AbstractListableResource<Beacon> {
     public BeaconResource(DAO<Beacon> dao) {
         super(dao);
+    }
+
+    @Override
+    @ApiOperation(value = "Find all beacons")
+    public List<Beacon> getListOf() {
+        return super.getListOf();
+    }
+
+    @Override
+    @ApiOperation(value = "Add a new beacon to the database")
+    public int create(Beacon beacon) {
+        return super.create(beacon);
+    }
+
+    @Override
+    @ApiOperation(value = "Find beacon by ID")
+    public Beacon get(Optional<Integer> id) {
+        return super.get(id);
+    }
+
+    @Override
+    @ApiOperation(value = "Update an existing beacon")
+    public Beacon update(Beacon beacon, Optional<Integer> id) {
+        return super.update(beacon, id);
+    }
+
+    @Override
+    @ApiOperation(value = "Delete an existing beacon")
+    public boolean delete(Optional<Integer> id) {
+        return super.delete(id);
     }
 }

--- a/src/main/java/telraam/api/DetectionResource.java
+++ b/src/main/java/telraam/api/DetectionResource.java
@@ -1,12 +1,18 @@
 package telraam.api;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import telraam.database.daos.DAO;
 import telraam.database.models.Detection;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Optional;
 
 @Path("/detection")
+@Api(value = "/detection") // Swagger
 @Produces(MediaType.APPLICATION_JSON)
 public class DetectionResource extends AbstractListableResource<Detection> {
 
@@ -14,4 +20,33 @@ public class DetectionResource extends AbstractListableResource<Detection> {
         super(dao);
     }
 
+    @Override
+    @ApiOperation(value = "Find all detections")
+    public List<Detection> getListOf() {
+        return super.getListOf();
+    }
+
+    @Override
+    @ApiOperation(value = "Add a new detection to the database")
+    public int create(Detection detection) {
+        return super.create(detection);
+    }
+
+    @Override
+    @ApiOperation(value = "Find detection by ID")
+    public Detection get(Optional<Integer> id) {
+        return super.get(id);
+    }
+
+    @Override
+    @ApiOperation(value = "Update an existing detection")
+    public Detection update(Detection detection, Optional<Integer> id) {
+        return super.update(detection, id);
+    }
+
+    @Override
+    @ApiOperation(value = "Delete an existing detection")
+    public boolean delete(Optional<Integer> id) {
+        return super.delete(id);
+    }
 }

--- a/src/main/java/telraam/api/LapResource.java
+++ b/src/main/java/telraam/api/LapResource.java
@@ -1,5 +1,7 @@
 package telraam.api;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import telraam.database.daos.LapDAO;
 import telraam.database.models.Lap;
 
@@ -9,8 +11,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
+import java.util.Optional;
 
 @Path("/lap")
+@Api("/lap")
 @Produces(MediaType.APPLICATION_JSON)
 public class LapResource extends AbstractResource<Lap> {
     private final LapDAO lapDAO;
@@ -21,11 +25,36 @@ public class LapResource extends AbstractResource<Lap> {
     }
 
     @GET
+    @ApiOperation(value = "Find all laps")
     public List<Lap> getListOf(@QueryParam("source") final Integer source) {
         if (source == null) {
             return lapDAO.getAll();
         } else {
             return lapDAO.getAllBySource(source);
         }
+    }
+
+    @Override
+    @ApiOperation(value = "Add a new lap to the database")
+    public int create(Lap lap) {
+        return super.create(lap);
+    }
+
+    @Override
+    @ApiOperation(value = "Find lap by ID")
+    public Lap get(Optional<Integer> id) {
+        return super.get(id);
+    }
+
+    @Override
+    @ApiOperation(value = "Update an existing lap")
+    public Lap update(Lap lap, Optional<Integer> id) {
+        return super.update(lap, id);
+    }
+
+    @Override
+    @ApiOperation(value = "Delete an existing lap")
+    public boolean delete(Optional<Integer> id) {
+        return super.delete(id);
     }
 }

--- a/src/main/java/telraam/api/LapSourceResource.java
+++ b/src/main/java/telraam/api/LapSourceResource.java
@@ -1,16 +1,51 @@
 package telraam.api;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import telraam.database.daos.DAO;
 import telraam.database.models.LapSource;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Optional;
 
 @Path("/lap-source")
+@Api("/lap-source")
 @Produces(MediaType.APPLICATION_JSON)
 public class LapSourceResource extends AbstractListableResource<LapSource> {
     public LapSourceResource(DAO<LapSource> dao) {
         super(dao);
+    }
+
+    @Override
+    @ApiOperation(value = "Find all lap sources")
+    public List<LapSource> getListOf() {
+        return super.getListOf();
+    }
+
+    @Override
+    @ApiOperation(value = "Add a new lap source to the database")
+    public int create(LapSource lapSource) {
+        return super.create(lapSource);
+    }
+
+    @Override
+    @ApiOperation(value = "Find lap source by ID")
+    public LapSource get(Optional<Integer> id) {
+        return super.get(id);
+    }
+
+    @Override
+    @ApiOperation(value = "Update an existing lap source")
+    public LapSource update(LapSource lapSource, Optional<Integer> id) {
+        return super.update(lapSource, id);
+    }
+
+    @Override
+    @ApiOperation(value = "Delete an existing lap source")
+    public boolean delete(Optional<Integer> id) {
+        return super.delete(id);
     }
 }

--- a/src/main/java/telraam/api/Resource.java
+++ b/src/main/java/telraam/api/Resource.java
@@ -2,7 +2,6 @@ package telraam.api;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import java.util.List;
 import java.util.Optional;
 
 public interface Resource<T> {

--- a/src/main/java/telraam/api/TeamResource.java
+++ b/src/main/java/telraam/api/TeamResource.java
@@ -1,14 +1,19 @@
 package telraam.api;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import telraam.database.daos.TeamDAO;
 import telraam.database.models.Team;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Optional;
 
 
 @Path("/team")
+@Api("/team")
 @Produces(MediaType.APPLICATION_JSON)
 public class TeamResource extends AbstractListableResource<Team> {
 
@@ -16,4 +21,33 @@ public class TeamResource extends AbstractListableResource<Team> {
         super(teamDAO);
     }
 
+    @Override
+    @ApiOperation(value = "Find all teams")
+    public List<Team> getListOf() {
+        return super.getListOf();
+    }
+
+    @Override
+    @ApiOperation(value = "Add a new team to the database")
+    public int create(Team team) {
+        return super.create(team);
+    }
+
+    @Override
+    @ApiOperation(value = "Find team by ID")
+    public Team get(Optional<Integer> id) {
+        return super.get(id);
+    }
+
+    @Override
+    @ApiOperation(value = "Update an existing team")
+    public Team update(Team team, Optional<Integer> id) {
+        return super.update(team, id);
+    }
+
+    @Override
+    @ApiOperation(value = "Delete an existing team")
+    public boolean delete(Optional<Integer> id) {
+        return super.delete(id);
+    }
 }

--- a/src/main/java/telraam/beacon/BeaconAggregator.java
+++ b/src/main/java/telraam/beacon/BeaconAggregator.java
@@ -24,13 +24,13 @@ public class BeaconAggregator extends TCPFactory<BeaconMessage>
     protected List<Callback<Void, Void>> exitHandlers = new ArrayList<>();
     protected List<Callback<Void, Void>> connectHandlers = new ArrayList<>();
 
-    // Create net Beacon Aggregtor, listening on this port.
+    // Create net Beacon Aggregator, listening on this port.
     public BeaconAggregator(int port) throws IOException {
         super(port);
         initializeCreator();
     }
 
-    // Create net Beacon Aggregtor, listening on a random port.
+    // Create net Beacon Aggregator, listening on a random port.
     public BeaconAggregator() throws IOException {
         super();
         initializeCreator();

--- a/src/main/resources/telraam/devConfig.yml
+++ b/src/main/resources/telraam/devConfig.yml
@@ -4,6 +4,9 @@ defaultName: ${DW_DEFAULT_NAME:-Stranger}
 
 beaconPort: 4564
 
+swagger:
+  resourcePackage: 'telraam.api'
+
 database:
   # the name of your JDBC driver
   driverClass: org.postgresql.Driver


### PR DESCRIPTION
http://localhost:8080/swagger

Om swagger de types te laten inspecteren moet een van de anotaties gebeuren in de niet abstracte klasse. Anders kan via `type erasion` en andere vage java dingen hij niet aan het type.
Ik koos voor `@ApiOperation` omdat die voor elke methode hetzelfde is, het de minst complexe anotation is, en het me de anduiding lijkt die het  meeste nut van haalt specifiek de tekst te kunnen aanpassen per ander type.

Het is jammer dat we nu toch in elke klasse de methodes moeten specifieren, maar ivm authenticatie denk ik dat dat sowieso nog zou gebeuren. (een detection lijkt me bijv. niet iets dat zomaar moet verwijdert kunnen worden via de api)