### PR TITLE
Add authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,12 @@ dependencies {
     testImplementation('org.mockito:mockito-core:3.12.4')
     testImplementation("io.dropwizard:dropwizard-testing:" + dropwizardVersion)
 
+
     // JAX-B dependencies for JDK 9+  -> https://stackoverflow.com/a/43574427
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
     implementation 'org.glassfish.jaxb:jaxb-runtime:3.0.1'
+
+    implementation 'org.javatuples:javatuples:1.2'
 }
 
 test {

--- a/src/main/java/telraam/App.java
+++ b/src/main/java/telraam/App.java
@@ -104,7 +104,6 @@ public class App extends Application<AppConfiguration> {
         environment.jersey().register(new AuthDynamicFeature(
                 new BasicCredentialAuthFilter.Builder<User>()
                         .setAuthenticator(credentials -> {
-                            // If the password is 'secret' then create a user with the specified username
                             if (validCredentials.containsKey(credentials.getUsername()) &&
                                     validCredentials.get(credentials.getUsername()).equals(credentials.getPassword())
                             ) {

--- a/src/main/java/telraam/AppConfiguration.java
+++ b/src/main/java/telraam/AppConfiguration.java
@@ -7,6 +7,7 @@ import telraam.api.responses.Template;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 public class AppConfiguration extends Configuration {
     @NotNull
@@ -16,6 +17,10 @@ public class AppConfiguration extends Configuration {
     private String defaultName = "Stranger";
 
     private int beaconPort;
+
+    @Valid
+    private List<ApplicationCredentialFactory> applicationCredentials;
+
     @Valid
     @NotNull
     private DataSourceFactory database = new DataSourceFactory();
@@ -57,12 +62,53 @@ public class AppConfiguration extends Configuration {
     @JsonProperty("beaconPort")
     public int getBeaconPort() {
         return beaconPort;
-
     }
 
     @JsonProperty("beaconPort")
     public void setBeaconPort(int port) {
         beaconPort = port;
+    }
 
+    @JsonProperty("applicationCredentials")
+    public List<ApplicationCredentialFactory> getApplicationCredentials() {
+        return applicationCredentials;
+    }
+
+    @JsonProperty("applicationCredentials")
+    public void setApplicationCredentials(List<ApplicationCredentialFactory> applicationCredentials) {
+        this.applicationCredentials = applicationCredentials;
+    }
+
+    static class ApplicationCredentialFactory extends Configuration {
+        String username;
+        String password;
+
+        @JsonProperty("username")
+        public String getUsername() {
+            return username;
+        }
+
+        @JsonProperty("username")
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        @JsonProperty("password")
+        public String getPassword() {
+            return password;
+        }
+
+        @JsonProperty("password")
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        @Override
+        public String toString() {
+            return "ApplicationCredentialFactory{" +
+                    "username='" + username + '\'' +
+                    ", password='" + password + '\'' +
+                    '}';
+        }
     }
 }

--- a/src/main/java/telraam/api/AbstractResource.java
+++ b/src/main/java/telraam/api/AbstractResource.java
@@ -1,8 +1,8 @@
 package telraam.api;
 
-import org.aopalliance.reflect.Class;
 import telraam.database.daos.DAO;
 
+import javax.annotation.security.PermitAll;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.util.Optional;
@@ -16,6 +16,7 @@ public abstract class AbstractResource<T> implements Resource<T> {
     }
 
     @Override
+    @PermitAll
     public int create(T t) {
         return dao.insert(t);
     }
@@ -27,7 +28,7 @@ public abstract class AbstractResource<T> implements Resource<T> {
             if (optional.isPresent()) {
                 return optional.get();
             } else {
-                throw new WebApplicationException(String.format("%s with id: %d not found", Class.class.getName(), id.get()), Response.Status.NOT_FOUND);
+                throw new WebApplicationException(String.format("%s with id: %d not found", this.getClass().getSimpleName(), id.get()), Response.Status.NOT_FOUND);
             }
         } else {
             throw new MissingIdException();
@@ -35,6 +36,7 @@ public abstract class AbstractResource<T> implements Resource<T> {
     }
 
     @Override
+    @PermitAll
     public T update(T t, Optional<Integer> id) {
         if (id.isPresent()) {
             Optional<T> optionalBaton = dao.getById(id.get());
@@ -50,6 +52,7 @@ public abstract class AbstractResource<T> implements Resource<T> {
     }
 
     @Override
+    @PermitAll
     public boolean delete(Optional<Integer> id) {
         if (id.isPresent()) {
             return dao.deleteById(id.get()) == 1;

--- a/src/main/java/telraam/api/HelloworldResource.java
+++ b/src/main/java/telraam/api/HelloworldResource.java
@@ -1,7 +1,10 @@
 package telraam.api;
 
 import com.codahale.metrics.annotation.Timed;
+import io.dropwizard.auth.Auth;
+import org.javatuples.Unit;
 import telraam.api.responses.Saying;
+import telraam.database.models.User;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -35,5 +38,11 @@ public class HelloworldResource {
     public Saying sayHello(@QueryParam("name") Optional<String> name) {
         final String value = String.format(template, name.orElse(defaultName));
         return new Saying(counter.incrementAndGet(), value);
+    }
+
+    @GET
+    @Path("/auth")
+    public Unit<Optional<User>> sayHelloAuth(@Auth Optional<User> userOpt) {
+        return Unit.with(userOpt);
     }
 }

--- a/src/main/java/telraam/api/Resource.java
+++ b/src/main/java/telraam/api/Resource.java
@@ -2,7 +2,6 @@ package telraam.api;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import java.util.List;
 import java.util.Optional;
 
 public interface Resource<T> {

--- a/src/main/java/telraam/database/models/User.java
+++ b/src/main/java/telraam/database/models/User.java
@@ -1,0 +1,10 @@
+package telraam.database.models;
+
+import java.security.Principal;
+
+public record User(String username) implements Principal {
+    @Override
+    public String getName() {
+        return username;
+    }
+}

--- a/src/main/resources/telraam/devConfig.yml
+++ b/src/main/resources/telraam/devConfig.yml
@@ -4,6 +4,10 @@ defaultName: ${DW_DEFAULT_NAME:-Stranger}
 
 beaconPort: 4564
 
+applicationCredentials:
+  - username: "trustedCrudUser"
+    password: "epicSecret"
+
 database:
   # the name of your JDBC driver
   driverClass: org.postgresql.Driver
@@ -24,7 +28,7 @@ database:
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s
 
-  # the SQL query to run when validating a connection's liveness
+  # the SQL query to run when validating a connection's liveliness
   validationQuery: "SELECT 1"
 
   # the timeout before a connection validation queries fail

--- a/src/main/resources/telraam/prodConfig.yml
+++ b/src/main/resources/telraam/prodConfig.yml
@@ -4,6 +4,10 @@ defaultName: ${DW_DEFAULT_NAME:-Stranger}
 
 beaconPort: 4564
 
+applicationCredentials:
+  - username: "possibleUserWithSomeAccess"
+    password: "aSecretForThisUser"
+
 database:
   driverClass: org.h2.Driver
   url: jdbc:h2:mem:telraam_test


### PR DESCRIPTION
also fix a classname lookup on a 404.

## Usage in code

No annotation means you don't need to be authenticated
`@PermitAll` means all authenticated users can access the resource
`@DenyAll` means nobody can access it
`@Auth Optional<User> userOpt` as path parameter means authentication is not required and gives you a user object, even for anonymous users. Useful to to remove authentication for 1 method when auth is required for the rest of the class

For more see the docs https://www.dropwizard.io/en/latest/manual/auth.html

## Using the api

Authenticate using basic auth specifying a username:password. The password is a common one at the moment. When it's valid, your specified username can be used for further authorization.
Password at the moment is **'secret'**.
All Create, Update and Delete methods now require authentication.

### Examples

Valid authentication:
`http -a username:secret localhost:8080/hello-world/auth`

Invalid authentication:
`http -a username:invalid localhost:8080/hello-world/auth`

Using curl:
`curl -u username:secret localhost:8080/hello-world/auth`