### PR TITLE
add index on detections

### DIFF
--- a/src/main/java/telraam/database/daos/BatonDAO.java
+++ b/src/main/java/telraam/database/daos/BatonDAO.java
@@ -28,10 +28,6 @@ public interface BatonDAO extends DAO<Baton> {
     @RegisterBeanMapper(Baton.class)
     Optional<Baton> getById(@Bind("id") int id);
 
-    @SqlQuery("SELECT * FROM baton WHERE mac = :mac")
-    @RegisterBeanMapper(Baton.class)
-    Optional<Baton> getByMAC(@Bind("mac") String mac);
-
     @Override
     @SqlUpdate("DELETE FROM baton WHERE id = :id")
     @RegisterBeanMapper(Baton.class)

--- a/src/main/java/telraam/station/Fetcher.java
+++ b/src/main/java/telraam/station/Fetcher.java
@@ -37,13 +37,13 @@ public class Fetcher {
     private final Logger logger = Logger.getLogger(Fetcher.class.getName());
 
     //Timeout to wait for before sending the next request after an error.
-    private final static int ERROR_TIMEOUT_MS = 1000;
+    private final static int ERROR_TIMEOUT_MS = 2000;
     //Timeout for a request to a station.
     private final static int REQUEST_TIMEOUT_S = 10;
     //Full batch size, if this number of detections is reached, more are probably available immediately.
     private final static int FULL_BATCH_SIZE = 1000;
     //Timeout when result has less than a full batch of detections.
-    private final static int IDLE_TIMEOUT_MS = 200;
+    private final static int IDLE_TIMEOUT_MS = 4000; // Wait 4 seconds
 
 
     public Fetcher(Jdbi database, Station station, Set<Lapper> lappers) {

--- a/src/main/resources/db/migration/V11__Add_index_on_detections.sql
+++ b/src/main/resources/db/migration/V11__Add_index_on_detections.sql
@@ -1,0 +1,1 @@
+create index detection_remote_id_station_id_index on detection (remote_id desc, station_id asc);


### PR DESCRIPTION
This PR adds an index to the detections table. We tested this on live data from the 6urenloop event and got a speedup from +-600ms for a request to +-60ms for the same query.

This pr also removes the fixes a n query problem.
Fetching 1000 detections will no longer result in 1003 queries. This has been reduced to 4.

:rocket: 