### PR TITLE
newbatonid can be nullable

### DIFF
--- a/src/main/resources/db/migration/V15__remove_null_constraint_on_newbatonid.sql
+++ b/src/main/resources/db/migration/V15__remove_null_constraint_on_newbatonid.sql
@@ -1,0 +1,1 @@
+alter table batonswitchover alter column newbatonid drop not null;


### PR DESCRIPTION
Closes #107 

- RobustLapper seems to not break when changed to `<null>`
- DeDenker needs to be verified (https://github.com/12urenloop/DeDenker/issues/8)