### PR TITLE
Slapper

### DIFF
--- a/src/main/java/telraam/App.java
+++ b/src/main/java/telraam/App.java
@@ -22,6 +22,7 @@ import telraam.healthchecks.TemplateHealthCheck;
 import telraam.logic.lapper.Lapper;
 import telraam.logic.lapper.external.ExternalLapper;
 import telraam.logic.lapper.robust.RobustLapper;
+import telraam.logic.lapper.slapper.Slapper;
 import telraam.logic.positioner.Positioner;
 import telraam.logic.positioner.simple.SimplePositioner;
 import telraam.station.Fetcher;
@@ -130,6 +131,7 @@ public class App extends Application<AppConfiguration> {
 
             lappers.add(new ExternalLapper(this.database));
             lappers.add(new RobustLapper(this.database));
+            lappers.add(new Slapper(this.database));
 
             // Enable lapper APIs
             for (Lapper lapper : lappers) {

--- a/src/main/java/telraam/logic/lapper/slapper/Slapper.java
+++ b/src/main/java/telraam/logic/lapper/slapper/Slapper.java
@@ -54,77 +54,77 @@ public class Slapper implements Lapper {
         this.jdbi.useHandle(handle -> handle.execute(
                         """
                                 WITH switchovers AS (
-                                    SELECT teamid AS team_id,
-                                        newbatonid,
-                                        timestamp AS start_timestamp,
-                                        COALESCE(
-                                            LEAD(timestamp) OVER (PARTITION BY teamid ORDER BY timestamp),
-                                            timestamp + INTERVAL '6 MONTHS'
-                                        ) AS next_baton_switch
-                                    FROM batonswitchover
+                                	SELECT teamid AS team_id,
+                                		newbatonid,
+                                		timestamp AS start_timestamp,
+                                		COALESCE(
+                                			LEAD(timestamp) OVER (PARTITION BY teamid ORDER BY timestamp),
+                                			timestamp + INTERVAL '1 MONTH'
+                                		) AS next_baton_switch
+                                	FROM batonswitchover
                                 ),
                                 team_detections AS (
-                                    SELECT MIN(station_id) AS station_id,
-                                        MAX(rssi) as rssi,
-                                        date_trunc('second', timestamp) AS timestamp_seconds,
-                                        team_id
-                                    FROM detection d
-                                    LEFT JOIN switchovers s ON d.baton_id = s.newbatonid
-                                        AND d.timestamp BETWEEN s.start_timestamp AND s.next_baton_switch
-                                    WHERE station_id NOT BETWEEN 3 AND 5
-                                        AND rssi > -85
-                                        AND team_id IS NOT NULL
-                                    GROUP BY date_trunc('second', timestamp), team_id
+                                	SELECT MIN(station_id) AS station_id,
+                                		MAX(rssi) as rssi,
+                                		date_trunc('second', timestamp) AS timestamp_seconds,
+                                		team_id
+                                	FROM detection d
+                                	LEFT JOIN switchovers s ON d.baton_id = s.newbatonid
+                                		AND d.timestamp BETWEEN s.start_timestamp AND s.next_baton_switch
+                                	WHERE station_id NOT BETWEEN 3 AND 5
+                                		AND rssi > -84
+                                		AND team_id IS NOT NULL
+                                	GROUP BY date_trunc('second', timestamp), team_id
                                 ),
-                                no_duplicates AS (
-                                    SELECT team_id,
-                                        timestamp_seconds,
-                                        FIRST_VALUE(timestamp_seconds) OVER (
-                                            PARTITION BY team_id
-                                            ORDER BY timestamp_seconds
-                                        ) AS first_timestamp_seconds
-                                    FROM (
-                                        SELECT *,
-                                            LAG(station_id) OVER (
-                                                PARTITION BY team_id
-                                                ORDER BY timestamp_seconds
-                                            ) AS prev_station_id
-                                        FROM team_detections
-                                    ) AS previous
-                                    WHERE station_id - prev_station_id <= -5
+                                start_times AS (
+                                	SELECT DISTINCT ON (team_id) team_id,
+                                		timestamp_seconds AS start_seconds
+                                	FROM team_detections
+                                	WHERE station_id BETWEEN 2 AND 3
+                                	ORDER BY team_id, timestamp_seconds
                                 ),
                                 new_laps AS (
-                                    SELECT team_id,
-                                        timestamp_seconds
-                                    FROM no_duplicates n_d
-                                    WHERE timestamp_seconds > first_timestamp_seconds
+                                	SELECT previous.team_id,
+                                		timestamp_seconds
+                                	FROM (
+                                		SELECT *,
+                                			LAG(station_id) OVER (
+                                				PARTITION BY team_id
+                                				ORDER BY timestamp_seconds
+                                			) AS prev_station_id
+                                		FROM team_detections
+                                	) AS previous
+                                	LEFT JOIN start_times s_t
+                                	ON previous.team_id = s_t.team_id
+                                	WHERE station_id - prev_station_id < -4
+                                		AND timestamp_seconds > start_seconds
                                 ),
                                 cst_source_id AS (
-                                    SELECT COALESCE(id, -1) AS source_id
-                                    FROM lap_source
-                                    WHERE name ILIKE 'slapper'
+                                	SELECT COALESCE(id, -1) AS source_id
+                                	FROM lap_source
+                                	WHERE name ILIKE 'slapper'
                                 ),
                                 deletions AS (
-                                    DELETE FROM lap l
-                                    WHERE lap_source_id = (SELECT source_id FROM cst_source_id)
-                                        AND NOT EXISTS (
-                                            SELECT 1
-                                            FROM new_laps n_l
-                                            WHERE l.team_id = n_l.team_id
-                                                AND l.timestamp = n_l.timestamp_seconds
-                                        )
+                                	DELETE FROM lap l
+                                	WHERE lap_source_id = (SELECT source_id FROM cst_source_id)
+                                		AND NOT EXISTS (
+                                			SELECT 1
+                                			FROM new_laps n_l
+                                			WHERE l.team_id = n_l.team_id
+                                				AND l.timestamp = n_l.timestamp_seconds
+                                		)
                                 )
                                 INSERT INTO lap (team_id, timestamp, lap_source_id)
                                 SELECT team_id,
-                                    timestamp_seconds,
-                                    source_id
+                                	timestamp_seconds,
+                                	source_id
                                 FROM new_laps n_l, cst_source_id
                                 WHERE NOT EXISTS (
-                                    SELECT 1
-                                    FROM lap l, cst_source_id
-                                    WHERE l.lap_source_id = source_id
-                                        AND l.team_id = n_l.team_id
-                                        AND l.timestamp = n_l.timestamp_seconds
+                                	SELECT 1
+                                	FROM lap l, cst_source_id
+                                	WHERE l.lap_source_id = source_id
+                                		AND l.team_id = n_l.team_id
+                                		AND l.timestamp = n_l.timestamp_seconds
                                 )
                                 """
                 )

--- a/src/main/java/telraam/logic/lapper/slapper/Slapper.java
+++ b/src/main/java/telraam/logic/lapper/slapper/Slapper.java
@@ -1,0 +1,139 @@
+package telraam.logic.lapper.slapper;
+
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import org.jdbi.v3.core.Jdbi;
+import telraam.database.daos.LapSourceDAO;
+import telraam.database.models.Detection;
+import telraam.database.models.LapSource;
+import telraam.logic.lapper.Lapper;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+// Lapper that only uses a single sql query
+public class Slapper implements Lapper {
+    private final String SOURCE_NAME = "slapper";
+    private final int DEBOUNCE_TIMEOUT = 10;
+    private final ScheduledExecutorService scheduler;
+    private boolean debounceScheduled;
+    private final Logger logger;
+    private final Jdbi jdbi;
+
+    public Slapper(Jdbi jdbi) {
+        this.jdbi = jdbi;
+        this.scheduler = Executors.newScheduledThreadPool(1);
+        this.logger = Logger.getLogger(Slapper.class.getName());
+        this.debounceScheduled = false;
+
+        // Get the lapSourceId, create the source if needed
+        LapSourceDAO lapSourceDAO = jdbi.onDemand(LapSourceDAO.class);
+        if (lapSourceDAO.getByName(SOURCE_NAME).isEmpty()) {
+            lapSourceDAO.insert(new LapSource(SOURCE_NAME));
+        }
+    }
+
+    @Override
+    public void handle(Detection msg) {
+        if (!this.debounceScheduled) {
+            this.debounceScheduled = true;
+            this.scheduler.schedule(() -> {
+                try {
+                    this.calculateLaps();
+                } catch (Exception e) {
+                    logger.severe(e.getMessage());
+                }
+                this.debounceScheduled = false;
+            }, DEBOUNCE_TIMEOUT, TimeUnit.SECONDS);
+        }
+    }
+
+    private void calculateLaps() {
+        logger.info("Slapper: Calculating laps...");
+        this.jdbi.useHandle(handle -> handle.execute(
+                        """
+                                WITH switchovers AS (
+                                    SELECT teamid AS team_id,
+                                        newbatonid,
+                                        timestamp AS start_timestamp,
+                                        COALESCE(
+                                            LEAD(timestamp) OVER (PARTITION BY teamid ORDER BY timestamp),
+                                            timestamp + INTERVAL '6 MONTHS'
+                                        ) AS next_baton_switch
+                                    FROM batonswitchover
+                                ),
+                                team_detections AS (
+                                    SELECT MIN(station_id) AS station_id,
+                                        MAX(rssi) as rssi,
+                                        date_trunc('second', timestamp) AS timestamp_seconds,
+                                        team_id
+                                    FROM detection d
+                                    LEFT JOIN switchovers s ON d.baton_id = s.newbatonid
+                                        AND d.timestamp BETWEEN s.start_timestamp AND s.next_baton_switch
+                                    WHERE station_id NOT BETWEEN 3 AND 5
+                                        AND rssi > -85
+                                        AND team_id IS NOT NULL
+                                    GROUP BY date_trunc('second', timestamp), team_id
+                                ),
+                                no_duplicates AS (
+                                    SELECT team_id,
+                                        timestamp_seconds,
+                                        FIRST_VALUE(timestamp_seconds) OVER (
+                                            PARTITION BY team_id
+                                            ORDER BY timestamp_seconds
+                                        ) AS first_timestamp_seconds
+                                    FROM (
+                                        SELECT *,
+                                            LAG(station_id) OVER (
+                                                PARTITION BY team_id
+                                                ORDER BY timestamp_seconds
+                                            ) AS prev_station_id
+                                        FROM team_detections
+                                    ) AS previous
+                                    WHERE station_id - prev_station_id <= -5
+                                ),
+                                new_laps AS (
+                                    SELECT team_id,
+                                        timestamp_seconds
+                                    FROM no_duplicates n_d
+                                    WHERE timestamp_seconds > first_timestamp_seconds
+                                ),
+                                cst_source_id AS (
+                                    SELECT COALESCE(id, -1) AS source_id
+                                    FROM lap_source
+                                    WHERE name ILIKE 'slapper'
+                                ),
+                                deletions AS (
+                                    DELETE FROM lap l
+                                    WHERE lap_source_id = (SELECT source_id FROM cst_source_id)
+                                        AND NOT EXISTS (
+                                            SELECT 1
+                                            FROM new_laps n_l
+                                            WHERE l.team_id = n_l.team_id
+                                                AND l.timestamp = n_l.timestamp_seconds
+                                        )
+                                )
+                                INSERT INTO lap (team_id, timestamp, lap_source_id)
+                                SELECT team_id,
+                                    timestamp_seconds,
+                                    source_id
+                                FROM new_laps n_l, cst_source_id
+                                WHERE NOT EXISTS (
+                                    SELECT 1
+                                    FROM lap l, cst_source_id
+                                    WHERE l.lap_source_id = source_id
+                                        AND l.team_id = n_l.team_id
+                                        AND l.timestamp = n_l.timestamp_seconds
+                                )
+                                """
+                )
+        );
+        logger.info("Slapper: Done calculating laps");
+    }
+
+    @Override
+    public void registerAPI(JerseyEnvironment jersey) {
+
+    }
+}

--- a/src/main/java/telraam/logic/lapper/slapper/Slapper.java
+++ b/src/main/java/telraam/logic/lapper/slapper/Slapper.java
@@ -54,78 +54,78 @@ public class Slapper implements Lapper {
         this.jdbi.useHandle(handle -> handle.execute(
                         """
                                 WITH switchovers AS (
-                                	SELECT teamid AS team_id,
-                                		newbatonid,
-                                		timestamp AS start_timestamp,
-                                		COALESCE(
-                                			LEAD(timestamp) OVER (PARTITION BY teamid ORDER BY timestamp),
-                                			timestamp + INTERVAL '1 MONTH'
-                                		) AS next_baton_switch
-                                	FROM batonswitchover
-                                ),
-                                team_detections AS (
-                                	SELECT MIN(station_id) AS station_id,
-                                		MAX(rssi) as rssi,
-                                		date_trunc('second', timestamp) AS timestamp_seconds,
-                                		team_id
-                                	FROM detection d
-                                	LEFT JOIN switchovers s ON d.baton_id = s.newbatonid
-                                		AND d.timestamp BETWEEN s.start_timestamp AND s.next_baton_switch
-                                	WHERE station_id NOT BETWEEN 3 AND 5
-                                		AND rssi > -84
-                                		AND team_id IS NOT NULL
-                                	GROUP BY date_trunc('second', timestamp), team_id
-                                ),
-                                start_times AS (
-                                	SELECT DISTINCT ON (team_id) team_id,
-                                		timestamp_seconds AS start_seconds
-                                	FROM team_detections
-                                	WHERE station_id BETWEEN 2 AND 3
-                                	ORDER BY team_id, timestamp_seconds
-                                ),
-                                new_laps AS (
-                                	SELECT previous.team_id,
-                                		timestamp_seconds
-                                	FROM (
-                                		SELECT *,
-                                			LAG(station_id) OVER (
-                                				PARTITION BY team_id
-                                				ORDER BY timestamp_seconds
-                                			) AS prev_station_id
-                                		FROM team_detections
-                                	) AS previous
-                                	LEFT JOIN start_times s_t
-                                	ON previous.team_id = s_t.team_id
-                                	WHERE station_id - prev_station_id < -4
-                                		AND timestamp_seconds > start_seconds
-                                ),
-                                cst_source_id AS (
-                                	SELECT COALESCE(id, -1) AS source_id
-                                	FROM lap_source
-                                	WHERE name ILIKE 'slapper'
-                                ),
-                                deletions AS (
-                                	DELETE FROM lap l
-                                	WHERE lap_source_id = (SELECT source_id FROM cst_source_id)
-                                		AND NOT EXISTS (
-                                			SELECT 1
-                                			FROM new_laps n_l
-                                			WHERE l.team_id = n_l.team_id
-                                				AND l.timestamp = n_l.timestamp_seconds
-                                		)
-                                )
-                                INSERT INTO lap (team_id, timestamp, lap_source_id)
-                                SELECT team_id,
-                                	timestamp_seconds,
-                                	source_id
-                                FROM new_laps n_l, cst_source_id
-                                WHERE NOT EXISTS (
-                                	SELECT 1
-                                	FROM lap l, cst_source_id
-                                	WHERE l.lap_source_id = source_id
-                                		AND l.team_id = n_l.team_id
-                                		AND l.timestamp = n_l.timestamp_seconds
-                                )
+                                 	SELECT teamid AS team_id,
+                                 		newbatonid,
+                                 		timestamp AS start_timestamp,
+                                 		COALESCE(
+                                 			LEAD(timestamp) OVER (PARTITION BY teamid ORDER BY timestamp),
+                                 			timestamp + INTERVAL '1 MONTH'
+                                 		) AS next_baton_switch
+                                 	FROM batonswitchover
+                                 ),
+                                 team_detections AS (
+                                 	SELECT station_id,
+                                 		MAX(rssi) as rssi,
+                                 		date_trunc('second', timestamp) AS timestamp_seconds,
+                                 		team_id
+                                 	FROM detection d
+                                 	LEFT JOIN switchovers s ON d.baton_id = s.newbatonid
+                                 		AND d.timestamp BETWEEN s.start_timestamp AND s.next_baton_switch
+                                 	WHERE station_id NOT BETWEEN 3 AND 5
+                                 		AND rssi > -84
+                                 		AND team_id IS NOT NULL
+                                 	GROUP BY date_trunc('second', timestamp), team_id, station_id
+                                 ),
+                                 start_times AS (
+                                 	SELECT DISTINCT ON (team_id) team_id,
+                                 		timestamp_seconds AS start_seconds
+                                 	FROM team_detections
+                                 	WHERE station_id BETWEEN 2 AND 3
+                                 	ORDER BY team_id, timestamp_seconds
+                                 ),
+                                 new_laps AS (
+                                 	SELECT previous.team_id,
+                                 		timestamp_seconds
+                                 	FROM (
+                                 		SELECT *,
+                                 			LAG(station_id) OVER (
+                                 				PARTITION BY team_id
+                                 				ORDER BY timestamp_seconds
+                                 			) AS prev_station_id
+                                 		FROM team_detections
+                                 	) AS previous
+                                 	LEFT JOIN start_times s_t
+                                 	ON previous.team_id = s_t.team_id
+                                 	WHERE station_id - prev_station_id < -4
+                                 		AND timestamp_seconds > start_seconds
+                                 ),
+                                 cst_source_id AS (
+                                 	SELECT COALESCE(id, -1) AS source_id
+                                 	FROM lap_source
+                                 	WHERE name ILIKE 'slapper'
+                                 ),
+                                 deletions AS (
+                                 	DELETE FROM lap l
+                                 	WHERE lap_source_id = (SELECT source_id FROM cst_source_id)
+                                 		AND NOT EXISTS (
+                                 			SELECT 1
+                                 			FROM new_laps n_l
+                                 			WHERE l.team_id = n_l.team_id
+                                 				AND l.timestamp = n_l.timestamp_seconds
+                                 		)
+                                 )
+                                 INSERT INTO lap (team_id, timestamp, lap_source_id)
+                                 SELECT team_id,
+                                 	timestamp_seconds,
+                                 	source_id
+                                 FROM new_laps n_l, cst_source_id
+                                 WHERE NOT EXISTS (
+                                 	SELECT 1
+                                 	FROM lap l, cst_source_id
+                                 	WHERE l.lap_source_id = source_id
+                                 		AND l.team_id = n_l.team_id
+                                 		AND l.timestamp = n_l.timestamp_seconds
+                                 )
                                 """
                 )
         );


### PR DESCRIPTION
# Slapper

Introducing Slapper, the lapper written in SQL!

### Logic

Slapper's lap-counting logic is inspired by `Robust Lapper`.
Both lappers determine if a new lap is completed by analyzing the difference between station IDs.
The main differences lay in the data preprocessing.

The objective is to identify a sequence of detections progressing sequentially from station 1 to 7. 
Slapper achieves this by selecting the most likely location of a runner every second and then filtering out any duplicate entries. 
For instance, if a runner is detected at station 1 for five consecutive seconds, only the first detection is retained.
This process results in a series of cycles spanning from station 1 to 7. 
The final step involves counting how many times the sequence returns from station 7 to 1.
To account for possible station failures baton transitions from station 6 to 1 or 7 to 2 are also accepted.

At last Slapper is sensitive to detections switching between 1 and 7 (whether intentional or accidental).
However these rare instances are filtered by the data preprocessing and seeing as it is a race it's unlikely someone will actually try this on purpose.

### Results

The following table shows the results of last years 12urenloop using three lapper: `External Lapper` (EL), `Robust Lapper` (RL) and Slapper (SL)

Team ID | EL  | RL  | SL   | Diff EL - RL | Diff EL - SL | Diff RL - SL 
---------------------------------------------------------------------------------------------
1  | 873 | 873 | 872  |  0 			| -1 		   | -1			  
2  | 867 | 867 | 865  |  0 			| -2  		   | -2			  
3  | 774 | 774 | 773  |  0 			| -1  		   | -1			  
4  | 738 | 738 | 738  |  0 			|  0  		   |  0			  
5  | 738 | 737 | 738  |  1 			|  0  		   |  0			  
8  | 693 | 693 | 693  |  0 			|  0  		   |  0   		  
9  | 672 | 673 | 673  |  1 			|  1  		   |  0			  
11 | 654 | 656 | 656  |  2 			|  2  		   |  0 		  
12 | 610 | 611 | 610  |  1 			|  0  		   | -1		 	  
14 | 586 | 586 | 586  |  0 			|  0  		   |  0			  
15 | 672 | 672 | 673  |  0 			|  1  		   |  1			  
16 | 611 | 611 | 611  |  0 			|  0  		   |  0			  
17 | 587 | 586 | 587  | -1 			|  0  		   |  1			  
18 | 580 | 580 | 580  |  0 			|  0  		   |  0			  
19 | 581 | 585 | 582  |  4 			|  1  		   | -3			  
20 | 577 | 576 | 576  | -1 			| -1  		   |  0			  
22 | 618 | 618 | 619  |  0 			|  1  	       |  1			  

Slapper sits somewhere between `External lapper` and `Robust Lapper`.

### Speed

Both `Robust Lapper` and Slapper were executed 20 times
10 times with an empty lap table and 10 times with an already filled lap table.

##### Empty lap table

_Robust Lapper_

- `Median`: 1 474 ms
- `Average`: 1 433.8 ms

_Slapper_

- `Median`: 638.5 ms
- `Average`: 628.6 ms

##### Filled lap table

_Robust Lapper_

- `Median`: 1 298 ms
- `Average`: 1 296.3 ms 

_Slapper_

- `Median`: 558.5 ms
- `Average`: 554.1 ms