### PR TITLE
refactor(detections): only store detections for which a baton is defined

### DIFF
--- a/src/main/java/telraam/database/daos/DetectionDAO.java
+++ b/src/main/java/telraam/database/daos/DetectionDAO.java
@@ -34,8 +34,10 @@ public interface DetectionDAO extends DAO<Detection> {
     int insertAll(@BindBean List<Detection> detection);
 
     @SqlBatch("""
-            INSERT INTO detection (station_id, baton_id, timestamp, rssi, battery, remote_id, uptime_ms, timestamp_ingestion) \
-            VALUES (:stationId, (SELECT id FROM baton WHERE mac = :batonMac), :timestamp, :rssi, :battery, :remoteId, :uptimeMs, :timestampIngestion)
+            INSERT INTO detection (station_id, baton_id, timestamp, rssi, battery, remote_id, uptime_ms, timestamp_ingestion)
+            SELECT :stationId, b.id, :timestamp, :rssi, :battery, :remoteId, :uptimeMs, :timestampIngestion
+            FROM baton b
+            WHERE b.mac = :batonMac
             """)
     @GetGeneratedKeys({"id", "baton_id"})
     @RegisterBeanMapper(Detection.class)


### PR DESCRIPTION
This will only save the detections for the batons which are in our database configured.
As we potentially need to run 2 instances for the 2025 editions we do not want to save the detections twice.